### PR TITLE
Exposure washout

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,12 +24,12 @@ Imports:
     magrittr,
     shiny,
     survival,
-    survminer,
-    duckdb
+    survminer
 Suggests: 
     devtools,
     roxygen2,
     testthat (>= 3.0.0),
     usethis,
-    pkgdown
+    pkgdown,
+    duckdb
 Config/testthat/edition: 3

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -15,8 +15,14 @@ app_server <- function(input, output, session) {
   
   
   if (tolower(DBMS) == "duckdb") {
-    connection <- DBI::dbConnect(duckdb::duckdb(), dbdir = DATABASE)
-    cdm <- CDMConnector::cdmFromCon(connection, cdmSchema = CDM_SCHEMA, writeSchema = WRITE_SCHEMA)
+    if (requireNamespace("duckdb", quietly = TRUE)) {
+      # duckdb is installed, proceed with connection
+      connection <- DBI::dbConnect(duckdb::duckdb(), dbdir = DATABASE)
+      cdm <- CDMConnector::cdmFromCon(connection, cdmSchema = CDM_SCHEMA, writeSchema = WRITE_SCHEMA)
+    } else {
+      stop("The 'duckdb' package is required to connect to local DuckDB files. ",
+           "Please install it using install.packages('duckdb') and try again.")
+    }
     
   } else {
     connectionDetails <- DatabaseConnector::createConnectionDetails(

--- a/R/calculateMatchedSurvivalData.R
+++ b/R/calculateMatchedSurvivalData.R
@@ -13,7 +13,10 @@
 #'   `concept_id` and `concept_name_id` (where `concept_name_id` holds the label).
 #'   Used for labeling results.
 #' @param matchRatio The target number of controls to match to each exposed person.
-#' @param washoutYears The washout period in years applied to each exposure and outcome.
+#' @param washoutYears The washout period in years. This is used to:
+#'   1. Define a required period of observation before an outcome event for initial cohort eligibility (`filterByWashoutAndGetOutcomeDates`).
+#'   2. Define a required period of observation before an exposure event for an individual to be included in the exposed cohort (`defineExposedCohortForPair`).
+#'   3. Define a required period of observation for a control *prior to the matched exposed's index date* (`performPairMatching`).
 #' @param session Optional. The Shiny session object. If provided, notifications
 #'   will be shown in the Shiny UI. Otherwise, messages are printed to the console.
 #'
@@ -26,7 +29,7 @@
 #'     \item{outcomeId}{Numeric ID of the outcome.}
 #'     \item{exposureLabel}{Character label for the exposure (from `conceptLabelLookup`).}
 #'     \item{outcomeLabel}{Character label for the outcome (from `conceptLabelLookup`).}
-#'     \item{nExposedIncludedInMatching}{Count of exposed individuals eligible for matching after applying outcome washout, exposure washout, observation period checks, and ensuring no outcome before exposure.}
+#'     \item{nExposedIdentifiedInitial}{Count of exposed individuals after initial definition (meeting exposure washout and outcome post-exposure criteria).}
 #'     \item{nExposedMatched}{Count of exposed individuals successfully matched to >=1 control.}
 #'     \item{nUnexposedMatched}{Total count of matched unexposed controls.}
 #'     \item{nTotalPersonsInAnalysis}{Total number of rows (persons) in the final `survivalData` for the pair.}
@@ -99,7 +102,7 @@ calculateMatchedSurvivalData <- function(selectedExposureIds,
     .notifyUser(paste("Preparing analysis for Outcome ID:", outcomeIdStr), duration = NA, id = prepOutcomeNotifId, session = session)
     
     # --- 5a. Filter by Outcome Washout & Get Outcome Dates ---
-
+    # This creates a base cohort eligible for this outcome (met outcome washout)
     washoutFilterResult <- filterByWashoutAndGetOutcomeDates(
       cohortBase = fullCohortBase,
       allConditionDates = allConditionFirstDates,
@@ -136,6 +139,7 @@ calculateMatchedSurvivalData <- function(selectedExposureIds,
       .notifyUser(paste("Processing Exposure ID:", exposureIdStr, "for Outcome ID:", outcomeIdStr), duration = NA, id = procPairNotifId, session = session)
       
       # --- 6a. Define Exposed Cohort for this Pair ---
+      # Exposed individuals must meet exposure washout and have outcome (if any) after exposure.
       exposedResult <- defineExposedCohortForPair(
         cohortBaseForOutcome = cohortBaseForOutcome,
         allConditionFirstDates = allConditionFirstDates,
@@ -156,27 +160,24 @@ calculateMatchedSurvivalData <- function(selectedExposureIds,
         next # Skip to next exposureId
       }
       
-      nExposedIdentifiedInitial <- nrow(exposedCohortDefinition) # Exposed after prior outcome check
+      nExposedIdentifiedInitial <- nrow(exposedCohortDefinition) # Exposed after washout and prior outcome check
       
       
-      # --- 6b. Define Controls Pool where matched patients are selected from ---
+      # --- 6b. Define Controls Pool for this Pair ---
+      # Starts with controlsPoolBaseOutcome (passed outcome washout).
+      # No further exposure-related washout applied here; that's handled in performPairMatching.
       controlsPoolForPair <- controlsPoolBaseOutcome %>%
-        dplyr::left_join(exposureDatesCurrentExposure, by = "person_id") %>%
-        dplyr::mutate(washout_end_date = obs_start_date %m+% lubridate::years(washoutYears)) %>%
-        # Keep if exposure is NA OR occurs ON or AFTER washout period end date
-        dplyr::filter(is.na(exposure_date) | exposure_date >= washout_end_date) %>%
-        # Select final columns needed for the matching pool
-        dplyr::select(person_id, year_of_birth, gender_concept_id, obs_start_date, obs_end_date, outcome_date)
+        dplyr::left_join(exposureDatesCurrentExposure, by = "person_id") # add exposure dates
       
       
       # --- 6c. Perform Matching for this Pair ---
       matchingResult <- performPairMatching(
-        exposedCohortDefinition = exposedCohortDefinition,
+        exposedCohort = exposedCohortDefinition,
         controlsPool = controlsPoolForPair,
-        exposureDatesCurrentExposure = exposureDatesCurrentExposure,
         matchRatio = matchRatio,
         exposureId = exposureId,
         outcomeId = outcomeId,
+        washoutYears = washoutYears,
         session = session
       )
       
@@ -194,7 +195,7 @@ calculateMatchedSurvivalData <- function(selectedExposureIds,
       # --- 6d. Calculate Survival for this Matched Pair ---
       survivalDataCurrentPair <- calculatePairSurvival(
         matchedDataFinal = matchedDataFinal,
-        cohortBaseForOutcome = cohortBaseForOutcome,
+        cohortBaseForOutcome = cohortBaseForOutcome, # Used to get observation periods for all matched individuals
         outcomeDatesCurrentOutcome = outcomeDatesCurrentOutcome,
         session = session
       )
@@ -213,7 +214,7 @@ calculateMatchedSurvivalData <- function(selectedExposureIds,
           survivalData = survivalDataCurrentPair,
           exposureId = exposureId, outcomeId = outcomeId,
           exposureLabel = exposureLabel, outcomeLabel = outcomeLabel,
-          nExposedIncludedInMatching = nExposedIdentifiedInitial,
+          nExposedIdentifiedInitial = nExposedIdentifiedInitial,
           nExposedMatched = nExposedMatched,
           nUnexposedMatched = sum(survivalDataCurrentPair$exposure_status == 0),
           nTotalPersonsInAnalysis = nrow(survivalDataCurrentPair)

--- a/R/survivalHelpers.R
+++ b/R/survivalHelpers.R
@@ -241,21 +241,27 @@ defineExposedCohortForPair <- function(cohortBaseForOutcome,
 #'
 #' Matches unexposed controls to exposed individuals based on incidence density
 #' sampling principles. Matching is performed on gender (exact) and age
-#' (nearest neighbor based on year of birth) within the risk set at the
-#' exposed individual's index date. Controls must be free of both the specific
-#' exposure and outcome prior to the index date.
+#' (nearest neighbor based on year of birth). Controls are selected from the
+#' risk set at the exposed individual's index date.
+#' 
+#' Control Eligibility Criteria applied within this function:
+#' 1. Must be under observation at the case's `index_date`.
+#' 2. Must have at least `washoutYears` of observation time *prior* to the case's `index_date`.
+#' 3. Must be free of the specific exposure event *prior to or on* the case's `index_date`.
+#' 4. Must be free of the specific outcome event *prior to or on* the case's `index_date`.
 #'
-#' @param exposedCohortDefinition A tibble of exposed individuals eligible for
+#' @param exposedCohort A tibble of exposed individuals eligible for
 #'   matching, as returned by `defineExposedCohortForPair`. Must contain
 #'   `exposed_person_id`, `index_date`, `year_of_birth`, `gender_concept_id`.
 #' @param controlsPool A tibble representing the potential control
-#'   pool (passed washout), containing `person_id`, `year_of_birth`,
-#'   `gender_concept_id`, `obs_start_date`, `obs_end_date`, and potentially `outcome_date`.
-#' @param exposureDatesCurrentExposure A tibble containing `person_id` and
-#'   `exposure_date` for the specific exposure being matched.
+#'   pool (passed outcome washout). Required columns: `person_id`,
+#'   `year_of_birth`, `gender_concept_id`, `obs_start_date`, `obs_end_date`,
+#'   `outcome_date` (can be NA), `exposure_date` (can be NA).
 #' @param matchRatio The target number of controls to match to each exposed person.
 #' @param exposureId The numeric concept ID of the exposure (for notifications).
 #' @param outcomeId The numeric concept ID of the outcome (for notifications).
+#' @param washoutYears The washout period in years, used to ensure unexposed controls have
+#'   a sufficient observation window prior to the exposed's `index_date`.
 #' @param session Optional. The Shiny session object.
 #'
 #' @return A list containing:
@@ -266,28 +272,24 @@ defineExposedCohortForPair <- function(cohortBaseForOutcome,
 #' Returns `NULL` for `matchedData` if no matched sets could be created.
 #'
 #' @keywords internal
-performPairMatching <- function(exposedCohortDefinition,
+performPairMatching <- function(exposedCohort,
                                 controlsPool,
-                                exposureDatesCurrentExposure,
                                 matchRatio,
                                 exposureId,
                                 outcomeId,
+                                washoutYears,
                                 session = NULL) {
   
-  if (is.null(exposedCohortDefinition) || nrow(exposedCohortDefinition) == 0) {
+  if (is.null(exposedCohort) || nrow(exposedCohort) == 0) {
     return(list(matchedData = NULL, nMatchedExposed = 0))
   }
   
   uniquePairKey <- paste0("pair_", exposureId, "_", outcomeId)
   matchProgId <- paste0("match_prog_", uniquePairKey)
   
-  # Prepare potential controls pool by adding exposure date info
-  potentialControlsPool <- controlsPool %>%
-    dplyr::left_join(exposureDatesCurrentExposure, by="person_id")
-  
   matchedSetsList <- list()
   nExposedMatched <- 0
-  totalExposedToMatch <- nrow(exposedCohortDefinition)
+  totalExposedToMatch <- nrow(exposedCohort)
   
   .notifyUser(
     paste0("Starting matching for Exp:", exposureId, ", Out:", outcomeId, " (", totalExposedToMatch, " exposed)"),
@@ -296,21 +298,27 @@ performPairMatching <- function(exposedCohortDefinition,
   on.exit(.removeUserNotify(id = matchProgId, session = session), add = TRUE)
   
   for (i in 1:totalExposedToMatch) {
-    currentExposed <- exposedCohortDefinition[i, ]
+    currentExposed <- exposedCohort[i, ]
     exposedPersonId <- currentExposed$exposed_person_id
     exposureIndexDate <- currentExposed$index_date
     exposedBirthYear <- currentExposed$year_of_birth
     exposedGender <- currentExposed$gender_concept_id
     
     # Define Risk Set for this Exposed Person
-    # Controls must be observed at index date and free of exposure & outcome before index date
-    riskSet <- potentialControlsPool %>%
+    riskSet <- controlsPool %>%
       dplyr::filter(
         person_id != exposedPersonId,
+        # CRITERION 1: Control must be under observation on exposed's exposure date
         obs_start_date <= exposureIndexDate,
         obs_end_date >= exposureIndexDate,
-        is.na(exposure_date) | exposure_date > exposureIndexDate, # Free of exposure up to index
-        is.na(outcome_date) | outcome_date > exposureIndexDate   # Free of outcome up to index
+        # CRITERION 2: Control must have `washoutYears` of observation before exposed case's index_date
+        (obs_start_date %m+% lubridate::years(washoutYears)) <= exposureIndexDate,
+        
+        # CRITERION 3: Control is UNEXPOSED to this specific exposure AT case's index_date
+        is.na(exposure_date) | exposure_date > exposureIndexDate,
+        
+        # CRITERION 4: Control is FREE of the current main outcome AT case's index_date
+        is.na(outcome_date) | outcome_date > exposureIndexDate
       )
     
     matchedControlsDf <- NULL

--- a/man/calculateMatchedSurvivalData.Rd
+++ b/man/calculateMatchedSurvivalData.Rd
@@ -28,7 +28,12 @@ Used for labeling results.}
 
 \item{matchRatio}{The target number of controls to match to each exposed person.}
 
-\item{washoutYears}{The washout period in years applied relative to each outcome.}
+\item{washoutYears}{The washout period in years. This is used to:
+\enumerate{
+\item Define a required period of observation before an outcome event for initial cohort eligibility (\code{filterByWashoutAndGetOutcomeDates}).
+\item Define a required period of observation before an exposure event for an individual to be included in the exposed cohort (\code{defineExposedCohortForPair}).
+\item Define a required period of observation for a control \emph{prior to the matched exposed's index date} (\code{performPairMatching}).
+}}
 
 \item{session}{Optional. The Shiny session object. If provided, notifications
 will be shown in the Shiny UI. Otherwise, messages are printed to the console.}
@@ -43,7 +48,7 @@ a list containing:
 \item{outcomeId}{Numeric ID of the outcome.}
 \item{exposureLabel}{Character label for the exposure (from \code{conceptLabelLookup}).}
 \item{outcomeLabel}{Character label for the outcome (from \code{conceptLabelLookup}).}
-\item{nExposedIncludedInMatching}{Count of exposed individuals after checking for prior outcomes.}
+\item{nExposedIdentifiedInitial}{Count of exposed individuals after initial definition (meeting exposure washout and outcome post-exposure criteria).}
 \item{nExposedMatched}{Count of exposed individuals successfully matched to >=1 control.}
 \item{nUnexposedMatched}{Total count of matched unexposed controls.}
 \item{nTotalPersonsInAnalysis}{Total number of rows (persons) in the final \code{survivalData} for the pair.}

--- a/man/defineExposedCohortForPair.Rd
+++ b/man/defineExposedCohortForPair.Rd
@@ -10,6 +10,7 @@ defineExposedCohortForPair(
   outcomeDatesCurrentOutcome,
   exposureId,
   outcomeId,
+  washoutYears,
   session = NULL
 )
 }
@@ -27,6 +28,9 @@ for the specific outcome being analyzed in the current loop iteration.}
 
 \item{outcomeId}{The numeric concept ID of the outcome condition.}
 
+\item{washoutYears}{The washout period in years. Exposure must occur on or after
+\code{obs_start_date + washoutYears}.}
+
 \item{session}{Optional. The Shiny session object.}
 }
 \value{
@@ -39,9 +43,10 @@ Returns \code{NULL} for \code{exposed} if no valid exposed individuals are found
 \code{NULL}for both \code{exposed} and \code{exposureDates} if \code{cohortBaseForOutcome} is null or empty
 }
 \description{
-Identifies individuals exposed to a specific condition within a
-pre-filtered (washout-applied) cohort. Ensures exposure occurs within
-the observation period and that the outcome (if present for the person)
-occurs strictly \emph{after} the exposure date.
+Identifies individuals exposed to a specific condition (\code{exposureId}) from a
+base cohort (already filtered by outcome washout), ensuring their exposure
+occurs AFTER the specified washout period relative to observation start,
+and BEFORE any occurrence of the specified outcome condition (\code{outcomeId}).
+Returns the filtered exposed cohort table and their exposure dates.
 }
 \keyword{internal}

--- a/man/filterByWashoutAndGetOutcomeDates.Rd
+++ b/man/filterByWashoutAndGetOutcomeDates.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/survivalHelpers.R
 \name{filterByWashoutAndGetOutcomeDates}
 \alias{filterByWashoutAndGetOutcomeDates}
-\title{Filter Cohort by Washout and Get Corresponding Outcome Dates}
+\title{Filter Cohort by Outcome Washout and Get Corresponding Outcome Dates}
 \usage{
 filterByWashoutAndGetOutcomeDates(
   cohortBase,

--- a/man/performPairMatching.Rd
+++ b/man/performPairMatching.Rd
@@ -5,32 +5,33 @@
 \title{Perform Incidence Density Matching for an Exposure-Outcome Pair}
 \usage{
 performPairMatching(
-  exposedCohortDefinition,
-  controlsPoolBaseOutcome,
-  exposureDatesCurrentExposure,
+  exposedCohort,
+  controlsPool,
   matchRatio,
   exposureId,
   outcomeId,
+  washoutYears,
   session = NULL
 )
 }
 \arguments{
-\item{exposedCohortDefinition}{A tibble of exposed individuals eligible for
+\item{exposedCohort}{A tibble of exposed individuals eligible for
 matching, as returned by \code{defineExposedCohortForPair}. Must contain
 \code{exposed_person_id}, \code{index_date}, \code{year_of_birth}, \code{gender_concept_id}.}
 
-\item{controlsPoolBaseOutcome}{A tibble representing the potential control
-pool (passed outcome washout), containing \code{person_id}, \code{year_of_birth},
-\code{gender_concept_id}, \code{obs_start_date}, \code{obs_end_date}, and potentially \code{outcome_date}.}
-
-\item{exposureDatesCurrentExposure}{A tibble containing \code{person_id} and
-\code{exposure_date} for the specific exposure being matched.}
+\item{controlsPool}{A tibble representing the potential control
+pool (passed outcome washout). Required columns: \code{person_id},
+\code{year_of_birth}, \code{gender_concept_id}, \code{obs_start_date}, \code{obs_end_date},
+\code{outcome_date} (can be NA), \code{exposure_date} (can be NA).}
 
 \item{matchRatio}{The target number of controls to match to each exposed person.}
 
 \item{exposureId}{The numeric concept ID of the exposure (for notifications).}
 
 \item{outcomeId}{The numeric concept ID of the outcome (for notifications).}
+
+\item{washoutYears}{The washout period in years, used to ensure unexposed controls have
+a sufficient observation window prior to the exposed's \code{index_date}.}
 
 \item{session}{Optional. The Shiny session object.}
 }
@@ -45,8 +46,16 @@ Returns \code{NULL} for \code{matchedData} if no matched sets could be created.
 \description{
 Matches unexposed controls to exposed individuals based on incidence density
 sampling principles. Matching is performed on gender (exact) and age
-(nearest neighbor based on year of birth) within the risk set at the
-exposed individual's index date. Controls must be free of both the specific
-exposure and outcome prior to the index date.
+(nearest neighbor based on year of birth). Controls are selected from the
+risk set at the exposed individual's index date.
+}
+\details{
+Control Eligibility Criteria applied within this function:
+\enumerate{
+\item Must be under observation at the case's \code{index_date}.
+\item Must have at least \code{washoutYears} of observation time \emph{prior} to the case's \code{index_date}.
+\item Must be free of the specific exposure event \emph{prior to or on} the case's \code{index_date}.
+\item Must be free of the specific outcome event \emph{prior to or on} the case's \code{index_date}.
+}
 }
 \keyword{internal}


### PR DESCRIPTION
Implement washout period to the exposure as well.

When matching unexposed controls, check that they have had "washoutYears" of exposure and outcome free observation before the matching date.